### PR TITLE
Update SonicBoomAbility.java

### DIFF
--- a/src/main/java/com/mc3699/smparch/archetype/miku/SonicBoomAbility.java
+++ b/src/main/java/com/mc3699/smparch/archetype/miku/SonicBoomAbility.java
@@ -91,7 +91,7 @@ public class SonicBoomAbility extends BaseAbility {
 
         for(LivingEntity e : level.getEntitiesOfClass(LivingEntity.class, box))
             if(!(e == owner)) {
-                if (e.hurt(level.damageSources().sonicBoom(owner), 10.0F)) {
+                if (e.hurt(level.damageSources().sonicBoom(owner), 7.0F)) {
 
                     double y  = 0.5 * (1.0 - e.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE));
                     double xz = 2.5 * (1.0 - e.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE));


### PR DESCRIPTION
i made sonic boom do 3.5 hearts (1 more than the spiran tenebrae archetype that isnt in the game yet sonic boom) because before it did half of someones hp